### PR TITLE
Update Flickr API to handle newer versions of PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "PHP client library for Flickr.",
     "require": {
         "php": ">=5.3.0",
-        "ext-curl": "0"
+        "ext-curl": "*"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "PHP client library for Flickr.",
     "require": {
         "php": ">=5.3.0",
-        "ext-curl": "*"
+        "ext-curl": ">=5.3.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,7 @@
     "type": "library",
     "description": "PHP client library for Flickr.",
     "require": {
-        "php": ">=5.3.0",
-        "ext-curl": ">=5.3.0"
+        "php": ">=5.3.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/DPZ/Flickr.php
+++ b/src/DPZ/Flickr.php
@@ -665,6 +665,9 @@ class Flickr
 
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, TRUE);
         curl_setopt($curl, CURLOPT_TIMEOUT, $this->httpTimeout);
+        
+        // CURLOPT_SAFE_UPLOAD defaulted to true in 5.6.0
+        curl_setopt($curl, CURLOPT_SAFE_UPLOAD, false);
 
         if ($this->method == 'POST')
         {

--- a/src/DPZ/Flickr.php
+++ b/src/DPZ/Flickr.php
@@ -679,6 +679,7 @@ class Flickr
         if ($this->method == 'POST')
         {
             if (is_array($parameters) && array_key_exists("photo", $parameters)) {
+                // https://binfalse.de/2016/06/21/forget-the-at-use-curl-file-create/
                 if (function_exists("curl_file_create")) {
                     $photo = $parameters["photo"];
                     $photo = ltrim($photo, "@");

--- a/src/DPZ/Flickr.php
+++ b/src/DPZ/Flickr.php
@@ -106,7 +106,7 @@ class Flickr
         if (session_id() == '') {
             session_start();
         }
-        
+
         $this->consumerKey = $key;
         $this->consumerSecret = $secret;
         $this->callback = $callback;
@@ -663,9 +663,9 @@ class Flickr
     {
         $curl = curl_init();
 
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, TRUE);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_TIMEOUT, $this->httpTimeout);
-        
+
         if (strnatcmp(phpversion(), '7.0.0') >= 0)
         {
             // disabling safe uploads is no longer supported in php 7
@@ -678,8 +678,18 @@ class Flickr
 
         if ($this->method == 'POST')
         {
+            if (is_array($parameters) && array_key_exists("photo", $parameters)) {
+                if (function_exists("curl_file_create")) {
+                    $photo = $parameters["photo"];
+                    $photo = ltrim($photo, "@");
+                    if (file_exists($photo)) {
+                        $photo = curl_file_create($photo);
+                        $parameters["photo"] = $photo;
+                    }
+                }
+            }
             curl_setopt($curl, CURLOPT_URL, $url);
-            curl_setopt($curl, CURLOPT_POST, TRUE);
+            curl_setopt($curl, CURLOPT_POST, true);
             curl_setopt($curl, CURLOPT_POSTFIELDS, $parameters);
         }
         else

--- a/src/DPZ/Flickr.php
+++ b/src/DPZ/Flickr.php
@@ -666,8 +666,15 @@ class Flickr
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, TRUE);
         curl_setopt($curl, CURLOPT_TIMEOUT, $this->httpTimeout);
         
-        // CURLOPT_SAFE_UPLOAD defaulted to true in 5.6.0
-        curl_setopt($curl, CURLOPT_SAFE_UPLOAD, false);
+        if (strnatcmp(phpversion(), '7.0.0') >= 0)
+        {
+            // disabling safe uploads is no longer supported in php 7
+        }
+        else if (strnatcmp(phpversion(), '5.6.0') >= 0)
+        {
+            // in php 5.6, curl option CURLOPT_SAFE_UPLOAD defaulted to true
+            curl_setopt($curl, CURLOPT_SAFE_UPLOAD, false);
+        }
 
         if ($this->method == 'POST')
         {


### PR DESCRIPTION
Before v5.6.0, the default value for CURLOPT_SAFE_UPLOAD was false, but since 5.6 it is now true - should be set in the httpRequest function to work properly on 5.6