### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "PHP client library for Flickr.",
     "require": {
         "php": ">=5.3.0",
-        "ext-curl": "0"
+        "ext-curl": ">=7.0.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
I got error from composer:
- dopiaza/dpzflickr 1.3 requires ext-curl == 0.0.0.0 -> the requested PHP extension curl has the wrong version (7.0.14) installed.